### PR TITLE
[#32] Improvement of errors display in CLI and GUI

### DIFF
--- a/src-tauri/src/alerts.rs
+++ b/src-tauri/src/alerts.rs
@@ -54,45 +54,81 @@ pub async fn get_github_security_alerts(app: tauri::AppHandle) -> Result<AlertsR
             .await
         {
             Ok(response) => {
-                if response.status() == 422 {
-                    // 422 Unprocessable Entity usually means Dependabot is not enabled
-                    eprintln!("Dependabot not enabled for {}", repo);
+                let status = response.status();
+
+                if status == 422 {
+                    // 422 Unprocessable Entity: Dependabot not enabled on this repo
+                    eprintln!("[{}] Dependabot not enabled (HTTP 422)", repo);
                     repo_alerts.push(RepoAlerts {
                         name: repo,
                         alerts: 0,
                         dependabot_enabled: false,
+                        error: None,
+                    });
+                } else if !status.is_success() {
+                    // Any other non-2xx: capture the raw body for a useful error message
+                    let body = response.text().await.unwrap_or_default();
+                    let msg = format!("HTTP {} — {}", status.as_u16(), body);
+                    eprintln!("[{}] GitHub API error: {}", repo, msg);
+                    repo_alerts.push(RepoAlerts {
+                        name: repo,
+                        alerts: 0,
+                        dependabot_enabled: false,
+                        error: Some(msg),
                     });
                 } else {
-                    match response.json::<Vec<GitHubAlert>>().await {
-                        Ok(alerts) => {
-                            let open_alerts = alerts.iter()
-                                .filter(|a| a.state == "open")
-                                .count();
-                            total_alerts += open_alerts;
-                            repo_alerts.push(RepoAlerts {
-                                name: repo,
-                                alerts: open_alerts,
-                                dependabot_enabled: true,
-                            });
+                    // 2xx: try to parse the JSON body
+                    // Read raw bytes first so we can log them if parsing fails
+                    match response.bytes().await {
+                        Ok(bytes) => {
+                            match serde_json::from_slice::<Vec<GitHubAlert>>(&bytes) {
+                                Ok(alerts) => {
+                                    let open_alerts = alerts.iter()
+                                        .filter(|a| a.state == "open")
+                                        .count();
+                                    total_alerts += open_alerts;
+                                    repo_alerts.push(RepoAlerts {
+                                        name: repo,
+                                        alerts: open_alerts,
+                                        dependabot_enabled: true,
+                                        error: None,
+                                    });
+                                }
+                                Err(e) => {
+                                    // Log the raw body so we can see what GitHub actually returned
+                                    let raw = String::from_utf8_lossy(&bytes);
+                                    let msg = format!("JSON parse error: {} — body: {}", e, raw);
+                                    eprintln!("[{}] {}", repo, msg);
+                                    repo_alerts.push(RepoAlerts {
+                                        name: repo,
+                                        alerts: 0,
+                                        dependabot_enabled: false,
+                                        error: Some(format!("JSON parse error: {}", e)),
+                                    });
+                                }
+                            }
                         }
                         Err(e) => {
-                            eprintln!("Failed to parse alerts for {}: {}", repo, e);
-                            // If parsing fails, assume Dependabot is not enabled
+                            let msg = format!("Error reading response body: {}", e);
+                            eprintln!("[{}] {}", repo, msg);
                             repo_alerts.push(RepoAlerts {
                                 name: repo,
                                 alerts: 0,
                                 dependabot_enabled: false,
+                                error: Some(msg),
                             });
                         }
                     }
                 }
             }
             Err(e) => {
-                eprintln!("Failed to fetch alerts for {}: {}", repo, e);
+                let msg = format!("Network error: {}", e);
+                eprintln!("[{}] {}", repo, msg);
                 repo_alerts.push(RepoAlerts {
                     name: repo,
                     alerts: 0,
                     dependabot_enabled: false,
+                    error: Some(msg),
                 });
             }
         }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -48,6 +48,7 @@ pub struct RepoAlerts {
     pub name: String,
     pub alerts: usize,
     pub dependabot_enabled: bool,
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/app/core/services/tauri/tauri.service.ts
+++ b/src/app/core/services/tauri/tauri.service.ts
@@ -16,6 +16,7 @@ export interface RepoAlerts {
   name: string;
   alerts: number;
   dependabot_enabled: boolean;
+  error?: string;
 }
 
 export interface AlertsResponse {

--- a/src/app/shared/components/alerts-list/alerts-list.component.html
+++ b/src/app/shared/components/alerts-list/alerts-list.component.html
@@ -60,13 +60,15 @@
       </div>
       <div
         class="repo-badge"
-        [class.safe]="repo.alerts === 0 && repo.dependabot_enabled"
+        [class.safe]="repo.alerts === 0 && repo.dependabot_enabled && !repo.error"
         [class.danger]="repo.alerts > 0"
-        [class.disabled]="!repo.dependabot_enabled"
-        [attr.title]="!repo.dependabot_enabled ? 'Dependabot not enabled' : null"
+        [class.disabled]="!repo.dependabot_enabled && !repo.error"
+        [class.error]="!!repo.error"
+        [attr.title]="repo.error ? repo.error : (!repo.dependabot_enabled ? 'Dependabot not enabled' : null)"
       >
-        <i *ngIf="repo.alerts === 0 && repo.dependabot_enabled" class="ti ti-check"></i>
-        <i *ngIf="!repo.dependabot_enabled" class="ti ti-minus" style="color: #64748b"></i>
+        <i *ngIf="repo.alerts === 0 && repo.dependabot_enabled && !repo.error" class="ti ti-check"></i>
+        <i *ngIf="!repo.dependabot_enabled && !repo.error" class="ti ti-minus" style="color: #64748b"></i>
+        <i *ngIf="repo.error" class="ti ti-alert-circle"></i>
         <span *ngIf="repo.alerts > 0">{{ repo.alerts }}</span>
       </div>
     </div>

--- a/src/app/shared/components/alerts-list/alerts-list.component.scss
+++ b/src/app/shared/components/alerts-list/alerts-list.component.scss
@@ -179,6 +179,12 @@
       color: colors.$text-secondary;
       cursor: help;
     }
+
+    &.error {
+      background: rgba(colors.$danger-color, 0.1);
+      color: colors.$danger-color;
+      cursor: help;
+    }
   }
 }
 


### PR DESCRIPTION
# Description

Errors management and display can be improved in both CLI and GUI.
Errors returned by GitHub API were opaque: no HTTP code, no body. Thus some errors were hidden,
even if the origin was the API results.

RepoAlerts has been updated to bring the error message to the frontend.
HTTP errors management has been reviews with better JSON processing with serde.
Add in the GUI a new badge for error cases (red).

Fixes #32 

Now the logs can expose better details:
```text
[Orange-OpenSource/ouds-ios] GitHub API error: HTTP 403 — {"message":"Dependabot alerts are disabled for this repository.","documentation_url":"https://docs.github.com/rest/dependabot/alerts#list-dependabot-alerts-for-a-repository","status":"403"}
```

And the GUI uses a better display for errors with red badges:
<img width="466" height="646" alt="proposal" src="https://github.com/user-attachments/assets/e84e03c8-f5f4-4e17-9f5a-01570b12b730" />

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests (npm run test) that prove my fix is effective or that my feature works
